### PR TITLE
IBX-10570: Add script to prepare dev env for CI

### DIFF
--- a/bin/prepare_dev_env.mjs
+++ b/bin/prepare_dev_env.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const getConfigFileContent = () => {
+    const configFilePath = path.resolve('tsconfig.json');
+
+    if (!fs.existsSync(configFilePath)) {
+        throw new Error('tsconfig.json not found.');
+    }
+
+    const content = JSON.parse(fs.readFileSync(configFilePath, 'utf-8'));
+
+    return content;
+};
+const saveConfigFileContent = (content) => {
+    const configFilePath = path.resolve('tsconfig.json');
+    const contentJSON = JSON.stringify(content, null, 4);
+
+    fs.writeFileSync(configFilePath, `${contentJSON}\n`, 'utf-8');
+};
+
+execSync('composer install', { stdio: 'inherit', cwd: process.cwd() });
+execSync('yarn ibexa-generate-tsconfig --use-relative-paths', { stdio: 'inherit', cwd: process.cwd() });
+
+const currDir = path.dirname(fileURLToPath(import.meta.url));
+const componentsPath = path.resolve(currDir, '../packages/components/src');
+const isDev = fs.existsSync(componentsPath);
+const dirName = isDev ? 'src' : 'dist';
+const packageJsonContent = getConfigFileContent();
+const packagesToReplace = ['assets', 'components', 'core'];
+
+packagesToReplace.forEach((packageName) => {
+    packageJsonContent.compilerOptions.paths[`@ids-${packageName}/*`] = [
+        `./node_modules/@ibexa/design-system/packages/${packageName}/${dirName}/*`,
+    ];
+});
+
+saveConfigFileContent(packageJsonContent);
+
+/* eslint-disable no-console */
+console.log(
+    '\x1b[32m%s\x1b[0m',
+    '+------------------------------------------+',
+);
+console.log(
+    '\x1b[32m%s\x1b[0m',
+    '|  Dev environment prepared successfully.  |',
+);
+console.log(
+    '\x1b[32m%s\x1b[0m',
+    '+------------------------------------------+',
+);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "private": true,
   "type": "module",
   "prettier": "@ibexa/eslint-config/prettier",
+  "bin": {
+    "ids-prepare-dev-env": "./bin/prepare_dev_env.mjs"
+  },
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
| :ticket: Issue | IBX-10570 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/design-system-twig/pull/27

#### Description:
This scripts is created for env that doesn't have whole app instaled (like CI) - it's purpose is to add aliases for design system to TS config, so that linter could fetch types imports correctly.
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
